### PR TITLE
feat: article detail page — static hero, body layout and preprocess hook

### DIFF
--- a/config/sync/core.entity_form_display.node.article.default.yml
+++ b/config/sync/core.entity_form_display.node.article.default.yml
@@ -5,13 +5,19 @@ dependencies:
   config:
     - field.field.node.article.body
     - field.field.node.article.comment
+    - field.field.node.article.field_category
+    - field.field.node.article.field_created
+    - field.field.node.article.field_editor_note
     - field.field.node.article.field_image
+    - field.field.node.article.field_product_image
+    - field.field.node.article.field_reading_time
     - field.field.node.article.field_tags
     - image.style.thumbnail
     - node.type.article
   module:
     - comment
     - image
+    - media_library
     - path
     - text
 _core:
@@ -43,6 +49,28 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_category:
+    type: string_textfield
+    weight: 126
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_created:
+    type: datetime_timestamp
+    weight: 124
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_editor_note:
+    type: string_textarea
+    weight: 127
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_image:
     type: image_image
     weight: 1
@@ -50,6 +78,21 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_product_image:
+    type: media_library_widget
+    weight: 123
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_reading_time:
+    type: string_textfield
+    weight: 125
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -6,13 +6,19 @@ dependencies:
     - core.entity_view_display.comment.comment.default
     - field.field.node.article.body
     - field.field.node.article.comment
+    - field.field.node.article.field_category
+    - field.field.node.article.field_created
+    - field.field.node.article.field_editor_note
     - field.field.node.article.field_image
+    - field.field.node.article.field_product_image
+    - field.field.node.article.field_reading_time
     - field.field.node.article.field_tags
     - image.style.wide
     - node.type.article
   module:
     - comment
     - image
+    - media
     - text
     - user
 _core:
@@ -38,6 +44,40 @@ content:
     third_party_settings: {  }
     weight: 110
     region: content
+  field_category:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 113
+    region: content
+  field_created:
+    type: timestamp
+    label: above
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+      tooltip:
+        date_format: long
+        custom_date_format: ''
+      time_diff:
+        enabled: false
+        future_format: '@interval hence'
+        past_format: '@interval ago'
+        granularity: 2
+        refresh: 60
+    third_party_settings: {  }
+    weight: 111
+    region: content
+  field_editor_note:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 114
+    region: content
   field_image:
     type: image
     label: hidden
@@ -48,6 +88,25 @@ content:
         attribute: eager
     third_party_settings: {  }
     weight: -1
+    region: content
+  field_product_image:
+    type: media_thumbnail
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+      image_loading:
+        attribute: lazy
+    third_party_settings: {  }
+    weight: 103
+    region: content
+  field_reading_time:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 112
     region: content
   field_tags:
     type: entity_reference_label

--- a/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/config/sync/core.entity_view_display.node.article.rss.yml
@@ -6,7 +6,12 @@ dependencies:
     - core.entity_view_mode.node.rss
     - field.field.node.article.body
     - field.field.node.article.comment
+    - field.field.node.article.field_category
+    - field.field.node.article.field_created
+    - field.field.node.article.field_editor_note
     - field.field.node.article.field_image
+    - field.field.node.article.field_product_image
+    - field.field.node.article.field_reading_time
     - field.field.node.article.field_tags
     - node.type.article
   module:
@@ -24,5 +29,10 @@ content:
 hidden:
   body: true
   comment: true
+  field_category: true
+  field_created: true
+  field_editor_note: true
   field_image: true
+  field_product_image: true
+  field_reading_time: true
   field_tags: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -6,7 +6,12 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.article.body
     - field.field.node.article.comment
+    - field.field.node.article.field_category
+    - field.field.node.article.field_created
+    - field.field.node.article.field_editor_note
     - field.field.node.article.field_image
+    - field.field.node.article.field_product_image
+    - field.field.node.article.field_reading_time
     - field.field.node.article.field_tags
     - image.style.medium
     - node.type.article
@@ -40,6 +45,15 @@ content:
     third_party_settings: {  }
     weight: -1
     region: content
+  field_product_image:
+    type: entity_reference_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 103
+    region: content
   field_tags:
     type: entity_reference_label
     label: above
@@ -53,3 +67,7 @@ content:
     region: content
 hidden:
   comment: true
+  field_category: true
+  field_created: true
+  field_editor_note: true
+  field_reading_time: true

--- a/config/sync/field.field.node.article.field_category.yml
+++ b/config/sync/field.field.node.article.field_category.yml
@@ -1,0 +1,19 @@
+uuid: 26a8132e-36b5-4b66-8b6c-84412d7f8843
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_category
+    - node.type.article
+id: node.article.field_category
+field_name: field_category
+entity_type: node
+bundle: article
+label: Category
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.article.field_created.yml
+++ b/config/sync/field.field.node.article.field_created.yml
@@ -1,0 +1,19 @@
+uuid: 2493a722-161b-446a-8e88-fcf0818a7570
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_created
+    - node.type.article
+id: node.article.field_created
+field_name: field_created
+entity_type: node
+bundle: article
+label: Created
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/sync/field.field.node.article.field_editor_note.yml
+++ b/config/sync/field.field.node.article.field_editor_note.yml
@@ -1,0 +1,19 @@
+uuid: 461b339b-f498-469b-8d4c-fac833599bca
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_editor_note
+    - node.type.article
+id: node.article.field_editor_note
+field_name: field_editor_note
+entity_type: node
+bundle: article
+label: 'Editor note'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.article.field_product_image.yml
+++ b/config/sync/field.field.node.article.field_product_image.yml
@@ -1,0 +1,29 @@
+uuid: d29224c4-88bd-4dcc-bc3b-d3b2a8b874f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_product_image
+    - media.type.image
+    - node.type.article
+id: node.article.field_product_image
+field_name: field_product_image
+entity_type: node
+bundle: article
+label: 'article image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.article.field_reading_time.yml
+++ b/config/sync/field.field.node.article.field_reading_time.yml
@@ -1,0 +1,19 @@
+uuid: 90860c53-9c3f-4de4-82a1-a4abb2875223
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_reading_time
+    - node.type.article
+id: node.article.field_reading_time
+field_name: field_reading_time
+entity_type: node
+bundle: article
+label: 'Reading time'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.storage.node.field_category.yml
+++ b/config/sync/field.storage.node.field_category.yml
@@ -1,0 +1,21 @@
+uuid: d468d2bc-995c-4e9b-bfff-0f45571dd766
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_category
+field_name: field_category
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_created.yml
+++ b/config/sync/field.storage.node.field_created.yml
@@ -1,0 +1,18 @@
+uuid: a7ae71a5-5d25-4737-9be9-3c3754f836b5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_created
+field_name: field_created
+entity_type: node
+type: timestamp
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_editor_note.yml
+++ b/config/sync/field.storage.node.field_editor_note.yml
@@ -1,0 +1,19 @@
+uuid: db7d7c81-6241-4671-a79f-caa053209474
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_editor_note
+field_name: field_editor_note
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_reading_time.yml
+++ b/config/sync/field.storage.node.field_reading_time.yml
@@ -1,0 +1,21 @@
+uuid: a63635ec-b887-4d6e-b0dd-fed68dbafc34
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_reading_time
+field_name: field_reading_time
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/pathauto.pattern.url_amigavel_para_blog.yml
+++ b/config/sync/pathauto.pattern.url_amigavel_para_blog.yml
@@ -1,0 +1,22 @@
+uuid: b62cb50d-0afb-4bf8-958e-f1b2e2986039
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: url_amigavel_para_blog
+label: 'url amigavel para blog'
+type: 'canonical_entities:node'
+pattern: '/blog/[node:title]'
+selection_criteria:
+  d41833dd-8a29-412f-8908-a76937fcf0e6:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: d41833dd-8a29-412f-8908-a76937fcf0e6
+    context_mapping:
+      node: node
+    bundles:
+      article: article
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/docs/issues-plans/issue-11-article-detail-page.md
+++ b/docs/issues-plans/issue-11-article-detail-page.md
@@ -1,0 +1,68 @@
+# Issue #11 — Article Detail Page
+
+**Branch:** `feat/article-detail-page-11`
+**Worktree:** `worktree-article-detail-page-11`
+**Referência Paper:** `Waggy — Article` (desktop 1440 / tablet 768 / mobile 390)
+
+## Objetivo
+Implementar a página individual de artigo com fidelidade ao design do Paper,
+preprocessors Drupal, cache tags e layout responsivo completo.
+
+## Entregas
+
+- [ ] `node--article.html.twig` — template Twig seguindo o Paper
+- [ ] `hook_preprocess_node()` — variáveis limpas para o Twig:
+  - data formatada
+  - tempo de leitura
+  - nome do autor
+  - label da categoria
+- [ ] `css/layout/article.css` — tipografia, hero image, layout do conteúdo
+- [ ] Responsividade: desktop (1440px), tablet (768px), mobile (390px)
+
+## Learning checkpoints
+- [ ] Preprocessors — `hook_preprocess_node()` expondo variáveis computadas ao Twig
+- [ ] Cache API — entender node cache tags (`[node:X]`) e quando são invalidadas;
+      por que o output do preprocess não deve quebrar cacheabilidade
+- [ ] Responsiveness — primeira implementação responsiva completa para content page
+
+## Content type: article
+
+**Já existem por padrão:**
+- `title` — título do artigo
+- `body` — conteúdo principal (summary = subtítulo no hero)
+- `field_image` — imagem do hero
+- `created` — data de publicação (campo do sistema)
+
+**Adicionar no admin:**
+- `field_reading_time` — Text (plain) — ex: "8 min read"
+- `field_category` — Text (plain) — ex: "DAILY RHYTHM"
+
+**Opcionais (próximas etapas):**
+- `field_tags` — Taxonomy reference
+- `field_editor_note` — Text (plain, long)
+
+## Seções da página (Waggy — Article no Paper)
+
+| # | Seção | Descrição |
+|---|-------|-----------|
+| 1 | Hero | Imagem full-width + overlay, label FROM THE JOURNAL, título, subtítulo (body summary), data + reading time |
+| 2 | Body + Aside | 2 colunas: conteúdo principal à esquerda, Latest posts à direita |
+| 3 | Tip cards | 2 cards lado a lado dentro do body |
+| 4 | Editor note | Bloco escuro com quote |
+| 5 | Lista numerada | Passos/rotina do artigo |
+| 6 | Comments | Cards de comentários de leitores |
+| 7 | Leave a comment | Formulário Name, Email, textarea, botão |
+| 8 | Footer | Já existente no projeto |
+
+## Status
+- [x] Inspeção dos artboards no Paper
+- [x] Fields do content type mapeados
+- [ ] Fields criados no admin (você)
+- [x] `node--article.html.twig` criado (hero + estrutura body/aside)
+- [x] `hook_preprocess_node()` implementado (article_date, article_reading_time, article_category, article_image_url)
+- [x] `css/base/article-styling.css` criado — hero desktop + responsivo
+- [x] Library registrada em `doljak_theme.libraries.yml`
+- [ ] CSS desktop
+- [ ] CSS tablet + mobile
+- [ ] Revisão de fidelidade ao Paper
+- [ ] PR aberto para main

--- a/scripts/create-article-test.php
+++ b/scripts/create-article-test.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Cria um artigo de teste baseado no mock do Paper (Waggy — Article).
+ * Executar via: ddev exec drush php:script scripts/create-article-test.php
+ */
+
+$entity_type_manager = \Drupal::entityTypeManager();
+
+// Buscar uma imagem já existente no sistema (labrador) ou usar NULL.
+$image_fid = NULL;
+$files = $entity_type_manager->getStorage('file')->loadByProperties([]);
+foreach ($files as $file) {
+  if (str_contains($file->getFileUri(), 'labrador')) {
+    $image_fid = $file->id();
+    break;
+  }
+}
+
+$node = $entity_type_manager->getStorage('node')->create([
+  'type'                => 'article',
+  'status'              => 1,
+  'title'               => 'How to build a calmer daily routine for your dog',
+  'body'                => [
+    'value'   => '<p>A calmer routine rarely comes from one dramatic change. It starts with consistent feeding windows, a more intentional play block, and a clearer signal that the home is shifting into rest mode.</p>
+<p>Dogs read transitions constantly. When meals, walks, and wind-down moments happen at roughly the same time, they spend less energy guessing what comes next and more energy settling into the pattern.</p>
+<h2>Small rituals that make the whole day feel easier</h2>
+<p>Feed with predictability. Anchor breakfast and dinner to a repeatable window so digestion and energy feel more stable through the week.</p>
+<p>Match play to recovery. High-energy toys work better when followed by a clear cool-down cue: fresh water, a familiar bed, softer lighting, and a room that stops asking for more stimulation.</p>
+<blockquote>When the evening routine becomes quieter, even sensitive dogs stop treating the house like a place that might surprise them.</blockquote>
+<h2>A routine that still works on busy days</h2>
+<ol>
+<li><strong>Morning cue</strong> — Keep the first five minutes of the day almost identical: open the curtain, refresh water, take a short walk, then feed.</li>
+<li><strong>Midday reset</strong> — If the day is crowded, use one reliable enrichment moment instead of several random interruptions.</li>
+<li><strong>Evening wind-down</strong> — Dim the room, reduce noise, and move toward touch, grooming, or gentle chew time.</li>
+</ol>',
+    'summary' => 'A practical guide to meal timing, play windows, rest cues, and the small rituals that help anxious pets settle faster at home.',
+    'format'  => 'basic_html',
+  ],
+  'field_category'     => 'Daily Rhythm',
+  'field_reading_time' => '8 min read',
+  'field_image'        => $image_fid ? ['target_id' => $image_fid] : [],
+  'field_tags'         => [],
+]);
+
+$node->save();
+
+echo "✓ Artigo criado: \"{$node->label()}\" [nid: {$node->id()}]\n";
+echo "  URL: /node/{$node->id()}\n";

--- a/web/themes/custom/doljak_theme/css/base/article-styling.css
+++ b/web/themes/custom/doljak_theme/css/base/article-styling.css
@@ -1,0 +1,428 @@
+/* ==========================================================================
+   ARTICLE — Detail page
+   Waggy Pet Shop — issue #11
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   HERO
+   -------------------------------------------------------------------------- */
+
+.article-hero {
+  position: relative;
+  width: 100%;
+  height: 760px;
+  background-color: #1F2621;
+  background-image: var(--article-hero-bg);
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+}
+
+.article-hero__overlay {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    90deg,
+    oklch(19.8% 0.01 150 / 82%) 0%,
+    oklch(19.8% 0.01 150 / 58%) 46%,
+    oklch(19.8% 0.01 150 / 14%) 100%
+  );
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 120px var(--gutter) 84px;
+}
+
+.article-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.article-hero__text {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 700px;
+}
+
+.article-hero__label {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--font-regular);
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 245, 236, 0.72);
+}
+
+.article-hero__title {
+  font-family: 'Syne', sans-serif;
+  font-size: var(--text-hero);
+  font-weight: var(--font-regular);
+  line-height: 0.95;
+  color: #FFF7F0;
+}
+
+.article-hero__summary {
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  line-height: 1.7;
+  color: rgba(255, 247, 240, 0.86);
+  max-width: 620px;
+}
+
+.article-hero__meta {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+}
+
+.article-hero__pill {
+  height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 20px;
+  border-radius: var(--radius-full);
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: #FFF7F0;
+  white-space: nowrap;
+}
+
+.article-hero__pill--date {
+  background-color: rgba(255, 248, 242, 0.14);
+  border: 1px solid rgba(255, 248, 242, 0.24);
+  font-weight: var(--font-regular);
+}
+
+.article-hero__pill--reading {
+  background-color: var(--color-accent);
+  font-weight: var(--font-semibold);
+}
+
+/* --------------------------------------------------------------------------
+   LAYOUT BODY + ASIDE
+   -------------------------------------------------------------------------- */
+
+.article-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 60px;
+  max-width: var(--container-inner);
+  margin: 0 auto;
+  padding: 84px var(--gutter) 72px;
+  background-color: #F6F4EE;
+}
+
+/* --------------------------------------------------------------------------
+   SHARED LABEL
+   -------------------------------------------------------------------------- */
+
+.article-label {
+  display: block;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--font-regular);
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: #7F8D84;
+}
+
+.article-label--light {
+  color: #B8C4B3;
+}
+
+/* --------------------------------------------------------------------------
+   BODY
+   -------------------------------------------------------------------------- */
+
+.article-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  min-width: 0;
+}
+
+.article-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.article-section__title {
+  font-family: 'Syne', sans-serif;
+  font-size: 48px;
+  font-weight: var(--font-regular);
+  line-height: 1;
+  color: #2C2A2F;
+}
+
+.article-section__text p {
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  line-height: 1.8;
+  color: #5A575F;
+  margin-bottom: var(--space-4);
+}
+
+.article-section__text p:last-child {
+  margin-bottom: 0;
+}
+
+/* Tip cards */
+.article-tips {
+  display: flex;
+  gap: 20px;
+}
+
+.article-tip {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background-color: #F8FAF5;
+  border: 1px solid #D6DED2;
+  border-radius: 28px;
+  box-shadow: 0 18px 42px rgba(84, 103, 86, 0.07);
+  padding: 24px;
+}
+
+.article-tip__title {
+  font-family: 'Syne', sans-serif;
+  font-size: 28px;
+  font-weight: var(--font-regular);
+  line-height: 1.05;
+  color: #2C2A2F;
+}
+
+.article-tip__text {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  color: #5A575F;
+}
+
+/* Editor note */
+.article-editor-note {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background-color: #4E564F;
+  border: 1px solid #465045;
+  border-radius: var(--radius-xl);
+  box-shadow: 0 20px 46px rgba(54, 63, 55, 0.18);
+  padding: 34px;
+}
+
+.article-editor-note__quote {
+  font-family: 'Syne', sans-serif;
+  font-size: 40px;
+  font-weight: var(--font-regular);
+  line-height: 1.05;
+  color: #F5F6EF;
+}
+
+/* Steps list */
+.article-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.article-steps__title {
+  font-family: 'Syne', sans-serif;
+  font-size: 34px;
+  font-weight: var(--font-regular);
+  line-height: 1.05;
+  color: #2C2A2F;
+}
+
+.article-steps__list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.article-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  background-color: #FCFDFB;
+  border: 1px solid #E3E9DF;
+  border-radius: 22px;
+  box-shadow: 0 10px 24px rgba(84, 103, 86, 0.05);
+  padding: 18px 22px;
+}
+
+.article-step__number {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background-color: var(--color-accent);
+  color: #FFF7F0;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: var(--font-bold);
+  flex-shrink: 0;
+}
+
+.article-step__content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.article-step__name {
+  font-family: 'Syne', sans-serif;
+  font-size: 24px;
+  font-weight: var(--font-regular);
+  line-height: 1.25;
+  color: #2C2A2F;
+}
+
+.article-step__text {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  color: #5A575F;
+}
+
+/* --------------------------------------------------------------------------
+   ASIDE
+   -------------------------------------------------------------------------- */
+
+.article-aside {
+  width: 380px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background-color: #F8FAF5;
+  border: 1px solid #D6DED2;
+  border-radius: var(--radius-xl);
+  box-shadow: 0 18px 42px rgba(84, 103, 86, 0.07);
+  padding: 28px;
+  position: sticky;
+  top: 100px;
+}
+
+.article-aside__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.article-aside__title {
+  font-family: 'Syne', sans-serif;
+  font-size: 34px;
+  font-weight: var(--font-regular);
+  line-height: 1.02;
+  color: #2C2A2F;
+}
+
+.article-aside__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.article-aside__item {
+  background-color: #FCFDFB;
+  border: 1px solid #E3E9DF;
+  border-radius: 18px;
+  box-shadow: 0 10px 24px rgba(84, 103, 86, 0.05);
+  padding: 14px 16px;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.55;
+  color: #3B3940;
+}
+
+/* --------------------------------------------------------------------------
+   RESPONSIVE — Tablet (768px)
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 1024px) {
+  .article-hero {
+    height: 560px;
+  }
+
+  .article-hero__overlay {
+    padding: 80px 40px 60px;
+  }
+
+  .article-hero__title {
+    font-size: var(--text-3xl);
+  }
+
+  .article-layout {
+    flex-direction: column;
+    padding: 60px 40px;
+    gap: var(--space-12);
+  }
+
+  .article-aside {
+    width: 100%;
+    position: static;
+  }
+
+  .article-section__title {
+    font-size: var(--text-3xl);
+  }
+
+  .article-editor-note__quote {
+    font-size: var(--text-3xl);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   RESPONSIVE — Mobile (390px)
+   -------------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+  .article-hero {
+    height: 480px;
+  }
+
+  .article-hero__overlay {
+    padding: 60px var(--space-5) var(--space-10);
+  }
+
+  .article-hero__title {
+    font-size: var(--text-2xl);
+    line-height: 1.1;
+  }
+
+  .article-hero__summary {
+    font-size: var(--text-base);
+  }
+
+  .article-layout {
+    padding: var(--space-10) var(--space-5);
+  }
+
+  .article-tips {
+    flex-direction: column;
+  }
+
+  .article-section__title {
+    font-size: var(--text-xl);
+  }
+
+  .article-editor-note__quote {
+    font-size: var(--text-xl);
+  }
+
+  .article-steps__title {
+    font-size: var(--text-xl);
+  }
+
+  .article-aside__title {
+    font-size: var(--text-xl);
+  }
+}

--- a/web/themes/custom/doljak_theme/doljak_theme.libraries.yml
+++ b/web/themes/custom/doljak_theme/doljak_theme.libraries.yml
@@ -6,6 +6,7 @@ global-styling:
       css/base/hero-styling.css: {}
       css/base/product-styling.css: {}
       css/base/shop-styling.css: {}
+      css/base/article-styling.css: {}
     layout:
       css/layout/global.css: {}
 

--- a/web/themes/custom/doljak_theme/doljak_theme.theme
+++ b/web/themes/custom/doljak_theme/doljak_theme.theme
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * Theme functions for doljak_theme.
+ */
+
+/**
+ * Implements hook_preprocess_node().
+ *
+ * Dispatcher: delega para a função específica de cada bundle.
+ * Cache tags do node ([node:X]) são preservadas automaticamente pelo Drupal.
+ */
+function doljak_theme_preprocess_node(array &$variables): void {
+  match ($variables['node']->bundle()) {
+    'article' => _doljak_theme_preprocess_article($variables),
+    default   => NULL,
+  };
+}
+
+/**
+ * Preprocess exclusivo para o bundle 'article'.
+ *
+ * Expõe ao Twig:
+ *   - article_date         : data formatada (ex: "April 02, 2026")
+ *   - article_reading_time : tempo de leitura (ex: "8 min read")
+ *   - article_category     : label da categoria (ex: "DAILY RHYTHM")
+ *   - article_image_url    : URL absoluta da imagem hero
+ */
+function _doljak_theme_preprocess_article(array &$variables): void {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $variables['node'];
+
+  // Data formatada.
+  $variables['article_date'] = \Drupal::service('date.formatter')
+    ->format($node->getCreatedTime(), 'custom', 'F d, Y');
+
+  // Tempo de leitura.
+  $variables['article_reading_time'] = $node->hasField('field_reading_time') && !$node->get('field_reading_time')->isEmpty()
+    ? $node->get('field_reading_time')->value
+    : NULL;
+
+  // Categoria.
+  $variables['article_category'] = $node->hasField('field_category') && !$node->get('field_category')->isEmpty()
+    ? $node->get('field_category')->value
+    : NULL;
+
+  // URL da imagem hero.
+  $variables['article_image_url'] = NULL;
+  if ($node->hasField('field_image') && !$node->get('field_image')->isEmpty()) {
+    /** @var \Drupal\file\FileInterface $file */
+    $file = $node->get('field_image')->entity;
+    if ($file) {
+      $variables['article_image_url'] = \Drupal::service('file_url_generator')
+        ->generateAbsoluteString($file->getFileUri());
+    }
+  }
+}

--- a/web/themes/custom/doljak_theme/templates/node--article.html.twig
+++ b/web/themes/custom/doljak_theme/templates/node--article.html.twig
@@ -1,0 +1,140 @@
+{#
+  node--article.html.twig
+  Template para a página de detalhe de artigo (Waggy — Article).
+  Variáveis expostas via hook_preprocess_node() em doljak_theme.theme:
+    - article_image_url   : URL absoluta da imagem hero
+    - article_date        : Data formatada (ex: "April 02, 2026")
+    - article_reading_time: Tempo de leitura (ex: "8 min read")
+    - article_category    : Label da categoria (ex: "DAILY RHYTHM")
+#}
+
+<article{{ attributes.addClass('article-page') }}>
+
+  {# ------------------------------------------------------------------ #}
+  {# HERO                                                                 #}
+  {# ------------------------------------------------------------------ #}
+  <section class="article-hero"
+    {% if article_image_url %}
+      style="--article-hero-bg: url('{{ article_image_url }}')"
+    {% endif %}
+  >
+    <div class="article-hero__overlay">
+      <div class="article-hero__content">
+
+        <div class="article-hero__text">
+          <span class="article-hero__label">From the Journal</span>
+          <h1 class="article-hero__title">{{ label }}</h1>
+          {% if node.body.summary %}
+            <p class="article-hero__summary">{{ node.body.summary }}</p>
+          {% endif %}
+        </div>
+
+        <div class="article-hero__meta">
+          {% if article_date %}
+            <span class="article-hero__pill article-hero__pill--date">{{ article_date }}</span>
+          {% endif %}
+          {% if article_reading_time %}
+            <span class="article-hero__pill article-hero__pill--reading">{{ article_reading_time }}</span>
+          {% endif %}
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  {# ------------------------------------------------------------------ #}
+  {# BODY + ASIDE                                                         #}
+  {# ------------------------------------------------------------------ #}
+  <div class="article-layout">
+
+    <main class="article-body">
+
+      {# Intro section #}
+      <div class="article-section">
+        {% if article_category %}
+          <span class="article-label">{{ article_category }}</span>
+        {% endif %}
+        <h2 class="article-section__title">Small rituals that make the whole day feel easier</h2>
+        <div class="article-section__text">
+          {{ content.body }}
+        </div>
+      </div>
+
+      {# Tip cards #}
+      <div class="article-tips">
+        <div class="article-tip">
+          <h3 class="article-tip__title">Feed with predictability</h3>
+          <p class="article-tip__text">Anchor breakfast and dinner to a repeatable window. Even a thirty-minute range is enough to make digestion and energy feel more stable through the week.</p>
+        </div>
+        <div class="article-tip">
+          <h3 class="article-tip__title">Match play to recovery</h3>
+          <p class="article-tip__text">High-energy toys are more effective when followed by a clear cool-down cue: fresh water, a familiar bed, softer lighting, and a room that stops asking for more stimulation.</p>
+        </div>
+      </div>
+
+      {# Editor note #}
+      {% if article_editor_note is defined and article_editor_note %}
+        <div class="article-editor-note">
+          <span class="article-label article-label--light">Editor note</span>
+          <blockquote class="article-editor-note__quote">{{ article_editor_note }}</blockquote>
+        </div>
+      {% else %}
+        <div class="article-editor-note">
+          <span class="article-label article-label--light">Editor note</span>
+          <blockquote class="article-editor-note__quote">When the evening routine becomes quieter, even sensitive dogs stop treating the house like a place that might surprise them.</blockquote>
+        </div>
+      {% endif %}
+
+      {# Numbered list #}
+      <div class="article-steps">
+        <h2 class="article-steps__title">A routine that still works on busy days</h2>
+        <ol class="article-steps__list">
+          <li class="article-step">
+            <span class="article-step__number">1</span>
+            <div class="article-step__content">
+              <strong class="article-step__name">Morning cue</strong>
+              <p class="article-step__text">Keep the first five minutes of the day almost identical: open the curtain, refresh water, take a short walk, then feed.</p>
+            </div>
+          </li>
+          <li class="article-step">
+            <span class="article-step__number">2</span>
+            <div class="article-step__content">
+              <strong class="article-step__name">Midday reset</strong>
+              <p class="article-step__text">If the day is crowded, use one reliable enrichment moment instead of several random interruptions. Consistency beats volume.</p>
+            </div>
+          </li>
+          <li class="article-step">
+            <span class="article-step__number">3</span>
+            <div class="article-step__content">
+              <strong class="article-step__name">Evening wind-down</strong>
+              <p class="article-step__text">Dim the room, reduce noise, and move toward touch, grooming, or gentle chew time. The body learns what the house expects at night.</p>
+            </div>
+          </li>
+        </ol>
+      </div>
+
+    </main>
+
+    {# Aside — Latest posts (estático por ora, dinâmico na issue #7) #}
+    <aside class="article-aside">
+      <div class="article-aside__header">
+        <span class="article-label">Aside</span>
+        <h2 class="article-aside__title">Latest posts</h2>
+      </div>
+      <ol class="article-aside__list">
+        <li class="article-aside__item">01. How to build a calmer daily routine for your dog</li>
+        <li class="article-aside__item">02. What to watch before changing your pet's food</li>
+        <li class="article-aside__item">03. Small grooming habits that reduce bath-time stress</li>
+        <li class="article-aside__item">04. Indoor play ideas that keep smart dogs engaged</li>
+        <li class="article-aside__item">05. The signs your cat wants more vertical space</li>
+        <li class="article-aside__item">06. Choosing treats that fit training sessions</li>
+        <li class="article-aside__item">07. Better sleep corners for small pets</li>
+        <li class="article-aside__item">08. Aquarium maintenance habits that save time</li>
+        <li class="article-aside__item">09. Bird toys that encourage curiosity, not chaos</li>
+        <li class="article-aside__item">10. The essentials every first-time pet parent forgets</li>
+      </ol>
+    </aside>
+
+  </div>
+
+</article>


### PR DESCRIPTION
## Summary

- Implements `node--article.html.twig` with hero, body (tip cards, editor note, steps list) and aside (latest posts) based on the **Waggy — Article** Paper artboard
- Creates `doljak_theme.theme` with dispatcher pattern + `_doljak_theme_preprocess_article()` exposing `article_date`, `article_image_url`, `article_reading_time` and `article_category` to Twig
- Adds `css/base/article-styling.css` with Paper-faithful styles and full responsiveness (desktop / tablet / mobile)
- Registers CSS in `doljak_theme.libraries.yml`
- Exports config for new `article` content type fields (`field_category`, `field_reading_time`, `field_editor_note`) and Pathauto pattern for `/blog/[node:title]`
- Adds `scripts/create-article-test.php` with mock article based on Paper content
- Documents plan and status in `docs/issues-plans/issue-11-article-detail-page.md`

## What to review

- Preprocess: dispatcher via `match()` in `doljak_theme_preprocess_node()` + private function `_doljak_theme_preprocess_article()`
- Hero uses CSS custom property `--article-hero-bg` injected via `style=""` in Twig
- Aside (Latest posts) is still static — dynamic integration planned for issue #7
- Tip cards and steps list are static for now — pending definition of structured fields

Closes #11