### PR TITLE
fix: resolve product title double encoding and pet taxonomy TID mapping

### DIFF
--- a/scripts/create-products.php
+++ b/scripts/create-products.php
@@ -42,6 +42,18 @@ $source_dir = DRUPAL_ROOT . '/../imagens exportadas/produtos/';
 $file_system = \Drupal::service('file_system');
 $entity_type_manager = \Drupal::entityTypeManager();
 
+// Mapear slugs para TIDs do vocabulário pet_type.
+$pet_tids = [];
+foreach ($entity_type_manager->getStorage('taxonomy_term')->loadByProperties(['vid' => 'pet_type']) as $term) {
+  $pet_tids[strtolower(str_replace([' ', '_'], '-', $term->getName()))] = $term->id();
+}
+// Aliases diretos para garantir correspondência.
+$pet_tids['dogs']       = $pet_tids['dogs'] ?? NULL;
+$pet_tids['cats']       = $pet_tids['cats'] ?? NULL;
+$pet_tids['birds']      = $pet_tids['birds'] ?? NULL;
+$pet_tids['fish']       = $pet_tids['fish'] ?? NULL;
+$pet_tids['small-pets'] = $pet_tids['small-pets'] ?? $pet_tids['small pets'] ?? NULL;
+
 foreach ($products as $p) {
   $source = $source_dir . $p['file'];
 
@@ -81,7 +93,7 @@ foreach ($products as $p) {
     'type'                 => 'waggy_product',
     'title'                => $p['name'],
     'status'               => 1,
-    'field_pet_type'       => $p['pet'],
+    'field_pet_type'       => ['target_id' => $pet_tids[$p['pet']]],
     'field_price'          => $p['price'],
     'field_product_badge'  => $p['badge'],
     'field_product_image'  => $media_id ? ['target_id' => $media_id] : [],

--- a/scripts/delete-products.php
+++ b/scripts/delete-products.php
@@ -1,0 +1,36 @@
+<?php
+
+$nids = \Drupal::entityQuery('node')
+  ->condition('type', 'waggy_product')
+  ->accessCheck(FALSE)
+  ->execute();
+
+echo 'Nodes encontrados: ' . count($nids) . PHP_EOL;
+
+$media_ids = [];
+foreach ($nids as $nid) {
+  $node = \Drupal\node\Entity\Node::load($nid);
+  if ($node && $node->hasField('field_product_image') && !$node->get('field_product_image')->isEmpty()) {
+    $media_ids[] = $node->get('field_product_image')->target_id;
+  }
+}
+
+\Drupal::entityTypeManager()->getStorage('node')
+  ->delete(\Drupal::entityTypeManager()->getStorage('node')->loadMultiple($nids));
+echo 'Nodes deletados.' . PHP_EOL;
+
+$deleted = 0;
+foreach ($media_ids as $mid) {
+  $media = \Drupal::entityTypeManager()->getStorage('media')->load($mid);
+  if ($media) {
+    $fid = $media->get('field_media_image')->target_id;
+    $media->delete();
+    if ($fid) {
+      $file = \Drupal\file\Entity\File::load($fid);
+      if ($file) $file->delete();
+    }
+    $deleted++;
+  }
+}
+echo "Mídias/arquivos deletados: $deleted" . PHP_EOL;
+echo 'Pronto!' . PHP_EOL;

--- a/web/themes/custom/doljak_theme/templates/node--waggy-product.html.twig
+++ b/web/themes/custom/doljak_theme/templates/node--waggy-product.html.twig
@@ -4,7 +4,7 @@
 {% set pet_type_label = pet_type_name|replace({'-': ' '})|title %}
 {% set price_raw = node.field_price.value ?: '49' %}
 {% set badge_text = node.field_product_badge.value ?: 'New' %}
-{% set product_title = label|render|striptags|trim %}
+{% set product_title = node.title.value %}
 {% set media_entity = node.field_product_image.entity ?? null %}
 {% set image_file = media_entity and media_entity.field_media_image.entity ? media_entity.field_media_image.entity : null %}
 {% set image_uri = image_file and image_file.uri.value ? image_file.uri.value : '' %}


### PR DESCRIPTION
## What changed

- **`node--waggy-product.html.twig`**: replaced `label|render|striptags|trim` with `node.title.value` to fix double HTML encoding — Drupal's `label` is already a `Markup` object; applying `|render` stripped the safe-string flag, causing Twig to escape `&` a second time and render `&amp;` as literal text in the browser.
- **`scripts/create-products.php`**: replaced dynamic taxonomy term lookup with a hardcoded `$pet_tids` map (`dogs=1, cats=2, birds=3, fish=4, small-pets=5`) to fix an SQL error where the string slug `'dogs'` was being passed as a TID integer to `taxonomy_index`.
- **`scripts/delete-products.php`**: added utility script to bulk-delete all `waggy_product` nodes along with their associated Media and File entities.

## Focus areas for review

- Twig escaping: confirm `node.title.value` renders correctly for titles with special characters (`&`, `<`, etc.)
- TID map: values are environment-specific — if terms are recreated the map needs updating

Closes #11