### PR TITLE
feat: add footer content template and styling

### DIFF
--- a/web/themes/custom/doljak_theme/css/base/footer-styling.css
+++ b/web/themes/custom/doljak_theme/css/base/footer-styling.css
@@ -1,0 +1,394 @@
+/* ==========================================================================
+   FOOTER CONTENT
+   Estrutura do footer para uso em node/bloco dedicado
+   ========================================================================== */
+
+.footer-content {
+  padding: var(--space-20) var(--gutter) var(--space-16);
+}
+
+.footer-content__inner {
+  max-width: var(--container-inner);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.footer-content__top {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.8fr);
+  gap: 28px;
+}
+
+.footer-content__intro,
+.footer-content__signup,
+.footer-content__brand-panel,
+.footer-content__column {
+  border: 1px solid rgba(201, 170, 138, 0.24);
+  box-shadow: 0 24px 50px rgba(123, 92, 60, 0.08);
+}
+
+.footer-content__intro {
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.45), transparent 46%),
+    linear-gradient(135deg, #fff5ea 0%, #f2e0cb 100%);
+  border-radius: 38px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: 42px;
+}
+
+.footer-content__eyebrow,
+.footer-content__card-label,
+.footer-content__column-title {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.footer-content__eyebrow {
+  color: rgba(120, 84, 52, 0.82);
+}
+
+.footer-content__title {
+  font-family: 'Syne', sans-serif;
+  font-size: clamp(40px, 5vw, 68px);
+  font-weight: var(--font-regular);
+  line-height: 0.94;
+  color: #47372D;
+  max-width: 11ch;
+}
+
+.footer-content__copy {
+  max-width: 620px;
+}
+
+.footer-content__copy p {
+  color: #6C5B4E;
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  line-height: 1.85;
+}
+
+.footer-content__highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.footer-content__highlight {
+  align-items: center;
+  background-color: rgba(255, 251, 246, 0.75);
+  border: 1px solid rgba(201, 170, 138, 0.28);
+  border-radius: var(--radius-full);
+  color: #7A6656;
+  display: inline-flex;
+  font-family: var(--font-body);
+  font-size: 13px;
+  gap: 10px;
+  min-height: 42px;
+  padding: 0 18px;
+}
+
+.footer-content__highlight::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-accent);
+  box-shadow: 0 0 0 5px rgba(222, 156, 111, 0.14);
+}
+
+.footer-content__signup {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent),
+    linear-gradient(145deg, #444241 0%, #2E2B2A 100%);
+  border-radius: 34px;
+  color: #FFF6EF;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 100%;
+  padding: 34px 32px;
+}
+
+.footer-content__card-label {
+  color: rgba(255, 244, 235, 0.72);
+}
+
+.footer-content__card-title {
+  color: #FFF6EF;
+  font-family: 'Syne', sans-serif;
+  font-size: 38px;
+  font-weight: var(--font-regular);
+  line-height: 1;
+  max-width: 10ch;
+}
+
+.footer-content__card-copy {
+  color: rgba(255, 244, 235, 0.82);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.8;
+}
+
+.footer-content__form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: auto;
+}
+
+.footer-content__input {
+  appearance: none;
+  background-color: rgba(255, 249, 244, 0.12);
+  border: 1px solid rgba(255, 249, 244, 0.18);
+  border-radius: var(--radius-pill);
+  color: #FFF6EF;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  min-height: 56px;
+  outline: none;
+  padding: 0 20px;
+  width: 100%;
+}
+
+.footer-content__input::placeholder {
+  color: rgba(255, 244, 235, 0.56);
+}
+
+.footer-content__button {
+  appearance: none;
+  background-color: var(--color-accent);
+  border: 0;
+  border-radius: var(--radius-pill);
+  color: var(--color-text-white);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  min-height: 56px;
+  padding: 0 22px;
+  transition: transform var(--transition-fast), background-color var(--transition-fast);
+}
+
+.footer-content__button:hover,
+.footer-content__button:focus-visible {
+  background-color: var(--color-accent-dark);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.footer-content__main {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.75fr) minmax(0, 1.25fr);
+  gap: 28px;
+}
+
+.footer-content__brand-panel {
+  background-color: #F7EBDD;
+  border-radius: 34px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  padding: 34px 30px;
+}
+
+.footer-content__brand-mark {
+  align-items: center;
+  background-color: #FFF7EF;
+  border-radius: 28px;
+  color: #5A4638;
+  display: inline-flex;
+  font-family: var(--font-display);
+  font-size: 30px;
+  height: 72px;
+  justify-content: center;
+  width: 72px;
+}
+
+.footer-content__brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.footer-content__brand-name {
+  color: #4A3C31;
+  font-family: 'Syne', sans-serif;
+  font-size: 30px;
+  font-weight: var(--font-regular);
+  line-height: 1;
+}
+
+.footer-content__brand-text {
+  color: #6E5E51;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.8;
+}
+
+.footer-content__nav {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.footer-content__column {
+  background-color: #FFF8F1;
+  border-radius: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 28px 24px;
+}
+
+.footer-content__column-title {
+  color: #826A58;
+}
+
+.footer-content__links {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.footer-content__link-item {
+  display: flex;
+}
+
+.footer-content__link {
+  color: #4C3C31;
+  display: inline-flex;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: 1.5;
+  transition: color var(--transition-fast), transform var(--transition-fast);
+}
+
+.footer-content__link:hover,
+.footer-content__link:focus-visible,
+.footer-content__social-link:hover,
+.footer-content__social-link:focus-visible {
+  color: var(--color-accent-dark);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.footer-content__bottom {
+  align-items: center;
+  border-top: 1px solid rgba(201, 170, 138, 0.34);
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  padding-top: var(--space-5);
+}
+
+.footer-content__legal {
+  color: #7E6D5E;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.footer-content__social {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+}
+
+.footer-content__social-link {
+  color: #5C4B3F;
+  display: inline-flex;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: var(--font-medium);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition: color var(--transition-fast), transform var(--transition-fast);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 1080px) {
+  .footer-content {
+    padding-left: 42px;
+    padding-right: 42px;
+  }
+
+  .footer-content__top,
+  .footer-content__main {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-content__title {
+    max-width: none;
+  }
+}
+
+@media (max-width: 820px) {
+  .footer-content {
+    padding: var(--space-16) 24px var(--space-12);
+  }
+
+  .footer-content__intro,
+  .footer-content__signup,
+  .footer-content__brand-panel {
+    padding: 28px 24px;
+  }
+
+  .footer-content__nav {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-content__card-title {
+    font-size: 32px;
+  }
+
+  .footer-content__bottom {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 560px) {
+  .footer-content {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .footer-content__intro,
+  .footer-content__signup,
+  .footer-content__brand-panel,
+  .footer-content__column {
+    border-radius: 24px;
+    padding: 24px 18px;
+  }
+
+  .footer-content__title {
+    font-size: 34px;
+  }
+
+  .footer-content__copy p,
+  .footer-content__brand-text {
+    font-size: 15px;
+  }
+
+  .footer-content__highlight {
+    width: 100%;
+  }
+}

--- a/web/themes/custom/doljak_theme/doljak_theme.libraries.yml
+++ b/web/themes/custom/doljak_theme/doljak_theme.libraries.yml
@@ -8,6 +8,7 @@ global-styling:
       css/base/product-styling.css: {}
       css/base/shop-styling.css: {}
       css/base/article-styling.css: {}
+      css/base/footer-styling.css: {}
     layout:
       css/layout/global.css: {}
 

--- a/web/themes/custom/doljak_theme/templates/node--footer.html.twig
+++ b/web/themes/custom/doljak_theme/templates/node--footer.html.twig
@@ -1,0 +1,133 @@
+{#
+  node--footer.html.twig
+  Estrutura visual do footer para uso futuro dentro de um block type dedicado.
+  Nesta issue o escopo fica restrito a HTML/CSS, então a navegação e o bloco
+  de newsletter usam conteúdo estático de referência enquanto o bundle final
+  e os campos ainda não foram modelados.
+#}
+
+{% set footer_brand = label ?: 'Waggy Pet Shop' %}
+{% set footer_columns = [
+  {
+    title: 'Shop',
+    links: [
+      { label: 'Dog essentials', href: '#' },
+      { label: 'Cat comfort', href: '#' },
+      { label: 'Bird accessories', href: '#' },
+      { label: 'Small pet care', href: '#' }
+    ]
+  },
+  {
+    title: 'Journal',
+    links: [
+      { label: 'Daily routines', href: '#' },
+      { label: 'Nutrition notes', href: '#' },
+      { label: 'Grooming guides', href: '#' },
+      { label: 'Home setup tips', href: '#' }
+    ]
+  },
+  {
+    title: 'Support',
+    links: [
+      { label: 'Shipping & returns', href: '#' },
+      { label: 'Store pickup', href: '#' },
+      { label: 'Gift cards', href: '#' },
+      { label: 'Talk to the team', href: '#' }
+    ]
+  }
+] %}
+{% set footer_social_links = [
+  { label: 'Instagram', href: '#' },
+  { label: 'Pinterest', href: '#' },
+  { label: 'Facebook', href: '#' }
+] %}
+{% set footer_highlights = [
+  'Curated essentials for calmer routines',
+  'Editorial navigation inspired by the main footer',
+  'Responsive spacing tuned for block-based placement'
+] %}
+
+<section{{ attributes.addClass('footer-content') }}>
+  <div class="footer-content__inner">
+
+    <div class="footer-content__top">
+      <div class="footer-content__intro">
+        <span class="footer-content__eyebrow">Footer content</span>
+        <h2 class="footer-content__title">{{ footer_brand }}</h2>
+
+        <div class="footer-content__copy">
+          {% if content.body is not empty %}
+            {{ content.body }}
+          {% else %}
+            <p>
+              A warm footer block with clearer navigation, softer hierarchy,
+              and a friendlier invitation to keep browsing the pet shop.
+            </p>
+          {% endif %}
+        </div>
+
+        <ul class="footer-content__highlights" aria-label="Footer highlights">
+          {% for highlight in footer_highlights %}
+            <li class="footer-content__highlight">{{ highlight }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+
+      <aside class="footer-content__signup" aria-label="Newsletter signup preview">
+        <span class="footer-content__card-label">Stay close</span>
+        <h3 class="footer-content__card-title">Keep the footer useful, not noisy.</h3>
+        <p class="footer-content__card-copy">
+          Use this area for newsletter capture, product drops, or a short
+          service promise when the dedicated fields arrive.
+        </p>
+
+        <form class="footer-content__form" action="#" method="post">
+          <label class="visually-hidden" for="footer-content-email">Email address</label>
+          <input id="footer-content-email" class="footer-content__input" type="email" placeholder="Email address" />
+          <button class="footer-content__button" type="button">Join the list</button>
+        </form>
+      </aside>
+    </div>
+
+    <div class="footer-content__main">
+      <div class="footer-content__brand-panel">
+        <span class="footer-content__brand-mark">WG</span>
+        <div class="footer-content__brand-copy">
+          <strong class="footer-content__brand-name">{{ footer_brand }}</strong>
+          <p class="footer-content__brand-text">
+            Designed to translate the footer rhythm into a reusable content
+            block without losing the airy, editorial feel of the theme.
+          </p>
+        </div>
+      </div>
+
+      <nav class="footer-content__nav" aria-label="Footer navigation preview">
+        {% for column in footer_columns %}
+          <div class="footer-content__column">
+            <h3 class="footer-content__column-title">{{ column.title }}</h3>
+            <ul class="footer-content__links">
+              {% for link in column.links %}
+                <li class="footer-content__link-item">
+                  <a href="{{ link.href }}" class="footer-content__link">{{ link.label }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endfor %}
+      </nav>
+    </div>
+
+    <div class="footer-content__bottom">
+      <p class="footer-content__legal">Copyright 2026 {{ footer_brand }}. Crafted for pet-friendly browsing.</p>
+
+      <ul class="footer-content__social" aria-label="Social links preview">
+        {% for item in footer_social_links %}
+          <li>
+            <a href="{{ item.href }}" class="footer-content__social-link">{{ item.label }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+
+  </div>
+</section>


### PR DESCRIPTION
- add a dedicated \ structure for the footer content block
- add responsive footer styling and attach it to the theme global library
- keep the scope limited to HTML and CSS while the runtime footer bundle/block wiring is still pending
- review focus: markup structure, visual hierarchy, and whether the placeholder content shape matches the intended footer direction

Closes #26