### PR TITLE
fix: add settings.pantheon.php for Pantheon database and config sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Arquivos de configuração com dados sensíveis
 web/sites/*/settings*.php
 !web/sites/default/settings.php
+!web/sites/default/settings.pantheon.php
 web/sites/*/services*.yml
 
 # Arquivos gerados pelo usuário

--- a/web/sites/default/settings.pantheon.php
+++ b/web/sites/default/settings.pantheon.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Pantheon environment settings.
+ *
+ * Loaded automatically from settings.php when PANTHEON_ENVIRONMENT is set.
+ * Mirrors the role that settings.ddev.php plays for the local DDEV environment.
+ */
+
+if (!isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+  return;
+}
+
+// Database — credentials are injected by Pantheon via environment variables.
+$databases['default']['default'] = [
+  'database'  => $_ENV['DB_NAME'],
+  'username'  => $_ENV['DB_USER'],
+  'password'  => $_ENV['DB_PASSWORD'],
+  'host'      => $_ENV['DB_HOST'],
+  'port'      => $_ENV['DB_PORT'],
+  'driver'    => 'mysql',
+  'prefix'    => '',
+  'collation' => 'utf8mb4_general_ci',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+];
+
+// Hash salt — use Pantheon site UUID for uniqueness across environments.
+if (empty($settings['hash_salt'])) {
+  $settings['hash_salt'] = $_ENV['DRUPAL_HASH_SALT'] ?? hash('sha256', $_ENV['PANTHEON_SITE_UUID'] ?? 'pantheon-fallback');
+}
+
+// Config sync directory — committed to git, outside the files/ directory.
+if (empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = '../config/sync';
+}
+
+// Trusted host patterns — allow all Pantheon subdomains.
+$settings['trusted_host_patterns'] = [
+  '^.+\.pantheonsite\.io$',
+  '^.+\.pantheon\.io$',
+];
+
+// Skip permissions hardening — Pantheon manages file permissions.
+$settings['skip_permissions_hardening'] = TRUE;
+
+// Reverse proxy — Pantheon uses load balancers.
+$settings['reverse_proxy'] = TRUE;
+$settings['reverse_proxy_addresses'] = [$_SERVER['REMOTE_ADDR'] ?? ''];

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -880,6 +880,11 @@ if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev
   include __DIR__ . '/settings.ddev.php';
 }
 
+// Pantheon environment settings.
+if (isset($_ENV['PANTHEON_ENVIRONMENT']) && file_exists(__DIR__ . '/settings.pantheon.php')) {
+  include __DIR__ . '/settings.pantheon.php';
+}
+
 /**
  * Load local development override configuration, if available.
  *


### PR DESCRIPTION
- Add settings.pantheon.php with database credentials from Pantheon environment variables, config sync path, hash salt, trusted hosts and reverse proxy config
- Include settings.pantheon.php from settings.php when PANTHEON_ENVIRONMENT is set — mirrors the DDEV pattern with settings.ddev.php
- Add .gitignore exception so settings.pantheon.php is committed to git