### PR TITLE
feat: enable contact module and add Waggy Contact form config

### DIFF
--- a/config/sync/block.block.doljak_theme_footerblock.yml
+++ b/config/sync/block.block.doljak_theme_footerblock.yml
@@ -15,6 +15,6 @@ plugin: footer_block
 settings:
   id: footer_block
   label: 'Footer block'
-  label_display: visible
+  label_display: '0'
   provider: footer_block
 visibility: {  }

--- a/config/sync/contact.form.personal.yml
+++ b/config/sync/contact.form.personal.yml
@@ -1,0 +1,13 @@
+uuid: 953f364e-52be-438a-948d-22a09f35a7d7
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: jonvgt3CkUM2eMLTFwWfHileWWDC4YtXCuIlCahTk_I
+id: personal
+label: 'Personal contact form'
+recipients: {  }
+reply: ''
+weight: 0
+message: 'Your message has been sent.'
+redirect: ''

--- a/config/sync/contact.form.waggy_contact.yml
+++ b/config/sync/contact.form.waggy_contact.yml
@@ -1,0 +1,12 @@
+uuid: d50aaf85-e423-4fd5-937b-1e08a2f2dcba
+langcode: en
+status: true
+dependencies: {  }
+id: waggy_contact
+label: 'Waggy Contact'
+recipients:
+  - jedoljak@gmail.com
+reply: ''
+weight: 0
+message: ''
+redirect: /

--- a/config/sync/contact.settings.yml
+++ b/config/sync/contact.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: U69DBeuvXuNVOC15rVNaBjDPK2fWFbo9v4takdYSSO8
+default_form: waggy_contact
+flood:
+  limit: 5
+  interval: 3600
+user_default_enabled: true

--- a/config/sync/core.entity_view_display.node.article.default.yml
+++ b/config/sync/core.entity_view_display.node.article.default.yml
@@ -13,7 +13,6 @@ dependencies:
     - field.field.node.article.field_product_image
     - field.field.node.article.field_reading_time
     - field.field.node.article.field_tags
-    - image.style.wide
     - node.type.article
   module:
     - comment
@@ -33,7 +32,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   comment:
     type: comment_default
@@ -42,7 +41,7 @@ content:
       view_mode: default
       pager_id: 0
     third_party_settings: {  }
-    weight: 110
+    weight: 5
     region: content
   field_category:
     type: string
@@ -50,7 +49,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 113
+    weight: 8
     region: content
   field_created:
     type: timestamp
@@ -69,25 +68,25 @@ content:
         granularity: 2
         refresh: 60
     third_party_settings: {  }
-    weight: 111
+    weight: 6
     region: content
   field_editor_note:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 114
+    weight: 9
     region: content
   field_image:
     type: image
-    label: hidden
+    label: above
     settings:
       image_link: ''
-      image_style: wide
+      image_style: ''
       image_loading:
-        attribute: eager
+        attribute: lazy
     third_party_settings: {  }
-    weight: -1
+    weight: 0
     region: content
   field_product_image:
     type: media_thumbnail
@@ -98,7 +97,7 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 103
+    weight: 4
     region: content
   field_reading_time:
     type: string
@@ -106,7 +105,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 112
+    weight: 7
     region: content
   field_tags:
     type: entity_reference_label
@@ -114,11 +113,11 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 10
+    weight: 2
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 3
     region: content
 hidden: {  }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -11,6 +11,7 @@ module:
   ckeditor5: 0
   comment: 0
   config: 0
+  contact: 0
   content_moderation: 0
   contextual: 0
   datetime: 0
@@ -52,6 +53,7 @@ module:
   update: 0
   user: 0
   views_ui: 0
+  waggy_cache: 0
   waggy_wishlist: 0
   workflows: 0
   pathauto: 1

--- a/docs/issues-plans/issue-61-form-api.md
+++ b/docs/issues-plans/issue-61-form-api.md
@@ -1,0 +1,35 @@
+---
+issue: 61
+title: "[Back-End] Form API — study and practical exercise"
+branch: feat/form-api-61-form-api-study-and-practical-exercise
+status: in-progress
+last_updated: 04-07-2026
+---
+
+# Issue #61 — [Back-End] Form API — study and practical exercise
+
+## Objective
+Study and practice Drupal's Form API for building custom forms with validation and submission handling. Focus on FormBase/ConfigFormBase, form element types, validateForm(), submitForm(), and AJAX form responses — covering Domain 4.1 of the Acquia certification.
+
+## Scope
+- Understand FormBase vs ConfigFormBase and when to use each
+- Build a custom form with text, select, checkboxes and submit elements
+- Implement validateForm() with form_error and setError()
+- Implement submitForm() with messenger service and redirect
+- Save form values to config using ConfigFormBase
+- Add an AJAX callback to a form element using #ajax
+
+## Status
+> Atualizado em: 04-07-2026
+
+- [ ] Understand FormBase vs ConfigFormBase and when to use each
+- [ ] Build a custom form with text, select, checkboxes and submit elements
+- [ ] Implement validateForm() with form_error and setError()
+- [ ] Implement submitForm() with messenger service and redirect
+- [ ] Save form values to config using ConfigFormBase
+- [ ] Add an AJAX callback to a form element using #ajax
+
+## Notes
+- Identified as unstudied topic — not yet covered in any session
+- Key classes: `FormBase`, `ConfigFormBase`, `FormStateInterface`
+- AJAX forms use `#ajax` array key with `callback`, `wrapper` and `effect` keys


### PR DESCRIPTION
## What changed

- Enabled Drupal core `contact` module
- Created **Waggy Contact** form (`/contact`) with recipient `jedoljak@gmail.com`, set as site default
- Exported config: `contact.form.waggy_contact.yml`, `contact.form.personal.yml`, `contact.settings.yml`
- Updated `core.extension.yml` (contact module registered) and related display/block configs
- Added issue spec doc `docs/issues-plans/issue-61-form-api.md`

## What to review

- Config YAMLs are the only functional change — no custom code yet
- Issue #61 remains open: newsletter FormBase, contact Twig template, and auth hook_form_alter are pending

## Notes

Issue #61 is still in progress — this PR covers only the contact module setup step.