### PR TITLE
refactor: refine auth journey UI

### DIFF
--- a/docs/issues-plans/issue-97-auth-ui.md
+++ b/docs/issues-plans/issue-97-auth-ui.md
@@ -1,0 +1,36 @@
+---
+issue: 97
+title: "[Refactor] Auth journey UI and logout screen"
+branch: refactor/auth-ui-97-auth-journey-ui-and-logout-screen
+status: in-progress
+last_updated: 05-18-2026
+---
+
+# Issue #97 — [Refactor] Auth journey UI and logout screen
+
+## Objective
+Refactor the authentication journey UI starting from the current main branch. Use the real Drupal screens for login, register, forgot password, and logout as the source of truth, refine the visual direction in Paper, create the missing logout screen in Paper, and then bring the approved UI adjustments back into Drupal through updated CSS while preserving the existing Drupal form behavior.
+
+## Scope
+- Start the implementation branch/worktree from main, not from the issue #86 worktree
+- Capture or inspect the real Drupal login, register, forgot password, and logout screens as they render today
+- Use Paper to refine only the UI layer for login, register, and forgot password based on the current Drupal output
+- Create the logout screen design in Paper so the auth journey has a complete visual reference
+- Update Drupal CSS to match the refined Paper direction without changing Form API integration or auth behavior
+- Validate the updated login, register, forgot password, and logout screens across desktop, tablet, and mobile breakpoints
+
+## Status
+> Atualizado em: 05-18-2026
+
+- [x] Start the implementation branch/worktree from main, not from the issue #86 worktree
+- [x] Capture or inspect the real Drupal login, register, forgot password, and logout screens as they render today
+- [ ] Use Paper to refine only the UI layer for login, register, and forgot password based on the current Drupal output
+- [ ] Create the logout screen design in Paper so the auth journey has a complete visual reference
+- [x] Update Drupal CSS to match the refined Paper direction without changing Form API integration or auth behavior
+- [ ] Validate the updated login, register, forgot password, and logout screens across desktop, tablet, and mobile breakpoints
+
+## Notes
+- Initial UI pass used the screenshots provided by the user for login, register and password reset because DDEV/Docker access was not available inside the sandbox.
+- Added Drupal logout confirm support through `form--user-logout-confirm.html.twig` and `user_logout_confirm` form suggestion/classes.
+- Paper artboard `Waggy — Logout` was created, but content insertion was cancelled while the Paper MCP call was running slowly; needs a follow-up Paper pass.
+- Styled Drupal auth error/status messages so validation feedback is contained above the auth layout instead of rendering as loose text at the top of the page.

--- a/web/themes/custom/doljak_theme/css/base/auth-styling.css
+++ b/web/themes/custom/doljak_theme/css/base/auth-styling.css
@@ -3,20 +3,65 @@
    Login, register and password reset templates
    ========================================================================== */
 
+.messages-list:has(+ .auth-page),
+.messages:has(+ .auth-page),
+[data-drupal-messages]:has(+ .auth-page) {
+  margin: clamp(24px, 3vw, 40px) auto calc(var(--space-8) * -1);
+  max-width: var(--container-inner);
+  padding: 0 var(--gutter);
+  position: relative;
+  z-index: 1;
+}
+
+.messages-list:has(+ .auth-page) .messages,
+.messages:has(+ .auth-page),
+[data-drupal-messages]:has(+ .auth-page) .messages {
+  background: #ffffff;
+  border: 1px solid rgba(196, 122, 64, 0.26);
+  border-left: 4px solid var(--color-accent-dark);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  line-height: 1.65;
+  padding: var(--space-4) var(--space-5);
+}
+
+.messages-list:has(+ .auth-page) .messages__list,
+.messages:has(+ .auth-page) .messages__list,
+[data-drupal-messages]:has(+ .auth-page) .messages__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+}
+
+.messages-list:has(+ .auth-page) em,
+.messages:has(+ .auth-page) em,
+[data-drupal-messages]:has(+ .auth-page) em {
+  color: var(--color-accent-dark);
+  font-style: italic;
+}
+
 .auth-page {
   align-items: center;
+  background:
+    radial-gradient(circle at 76% 42%, rgba(222, 156, 111, 0.09), transparent 32%),
+    linear-gradient(90deg, rgba(250, 243, 237, 0.96), rgba(250, 243, 237, 0.7));
   display: flex;
-  min-height: calc(100vh - 80px - 160px);
+  min-height: calc(100vh - var(--site-header-bottom));
   width: 100%;
 }
 
 .auth-page__inner {
+  align-items: center;
   display: grid;
-  gap: var(--space-20);
+  gap: clamp(56px, 8vw, 128px);
   grid-template-columns: 55fr 45fr;
   margin: 0 auto;
   max-width: var(--container-inner);
-  padding: var(--space-20) var(--gutter);
+  padding: clamp(72px, 8vw, 120px) var(--gutter);
   width: 100%;
 }
 
@@ -24,7 +69,7 @@
   align-self: center;
   display: flex;
   flex-direction: column;
-  max-width: 560px;
+  max-width: 620px;
 }
 
 .auth-hero__eyebrow {
@@ -41,9 +86,10 @@
 .auth-reset__title {
   color: var(--color-text-primary);
   font-family: var(--font-display);
-  font-size: var(--text-3xl);
+  font-size: clamp(42px, 4.6vw, 72px);
   font-weight: var(--font-regular);
-  line-height: 1.15;
+  letter-spacing: 0;
+  line-height: 1.16;
 }
 
 .auth-hero__title {
@@ -54,7 +100,7 @@
 .auth-reset__subtitle {
   color: var(--color-text-secondary);
   font-family: var(--font-body);
-  font-size: var(--text-sm);
+  font-size: var(--text-md);
   line-height: 1.7;
 }
 
@@ -66,6 +112,14 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-4);
+}
+
+.auth-page--register .auth-page__inner {
+  align-items: start;
+}
+
+.auth-page--register .auth-hero {
+  padding-top: clamp(88px, 8vw, 136px);
 }
 
 .auth-stat {
@@ -95,24 +149,33 @@
 
 .auth-card {
   background: #ffffff;
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-lg);
-  padding: var(--space-12);
+  border: 1px solid rgba(237, 228, 216, 0.7);
+  border-radius: 22px;
+  box-shadow: 0 28px 70px rgba(65, 64, 64, 0.10);
+  justify-self: end;
+  max-width: 560px;
+  padding: clamp(40px, 4vw, 72px);
+  width: 100%;
 }
 
 .auth-card__title {
   color: var(--color-text-primary);
   font-family: var(--font-display);
-  font-size: var(--text-2xl);
+  font-size: clamp(40px, 4vw, 64px);
   font-weight: var(--font-regular);
   line-height: 1.1;
   margin-bottom: var(--space-2);
 }
 
+.auth-card__title--small {
+  font-size: var(--text-2xl);
+  margin-bottom: var(--space-4);
+}
+
 .auth-card__subtitle {
   color: var(--color-text-secondary);
   font-family: var(--font-body);
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   line-height: 1.7;
   margin-bottom: var(--space-8);
 }
@@ -125,7 +188,7 @@
 .auth-field {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--space-3);
   margin-bottom: var(--space-5);
 }
 
@@ -138,7 +201,7 @@
 .auth-field label {
   color: var(--color-text-primary);
   font-family: var(--font-body);
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   font-weight: var(--font-medium);
   line-height: 1.4;
 }
@@ -149,10 +212,10 @@
   border-radius: var(--radius-md);
   color: var(--color-text-primary);
   font-family: var(--font-body);
-  font-size: var(--text-sm);
-  min-height: 54px;
+  font-size: var(--text-base);
+  min-height: 66px;
   outline: none;
-  padding: var(--space-4) var(--space-5);
+  padding: var(--space-5) var(--space-6);
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
   width: 100%;
 }
@@ -166,6 +229,49 @@
   color: var(--color-text-light);
 }
 
+.auth-field .description,
+.auth-field .password-suggestions,
+.auth-field .password-confirm-message,
+.auth-field .password-strength,
+.auth-field .password-match {
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.auth-field .description {
+  margin-top: 2px;
+}
+
+.auth-field .password-strength {
+  margin-top: var(--space-1);
+}
+
+.auth-field .password-strength__meter {
+  background: rgba(65, 64, 64, 0.12);
+  border-radius: var(--radius-full);
+  height: 8px;
+  margin-bottom: var(--space-2);
+}
+
+.auth-field .password-strength__indicator {
+  background: var(--color-accent);
+  border-radius: inherit;
+  height: 100%;
+}
+
+.auth-field .password-strength__title,
+.auth-field .password-match {
+  color: var(--color-text-primary);
+  font-size: 14px;
+  margin-top: var(--space-2);
+}
+
+.auth-field .password-confirm {
+  margin-top: var(--space-4);
+}
+
 .btn {
   align-items: center;
   border: 1px solid transparent;
@@ -176,7 +282,7 @@
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   justify-content: center;
-  min-height: 54px;
+  min-height: 66px;
   padding: var(--space-4) var(--space-8);
   text-decoration: none;
   transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
@@ -278,8 +384,8 @@
 
 .auth-reset__inner {
   margin: 0 auto;
-  max-width: 480px;
-  padding: var(--space-20) var(--gutter);
+  max-width: 560px;
+  padding: clamp(72px, 8vw, 120px) var(--gutter);
   width: 100%;
 }
 
@@ -292,7 +398,27 @@
 }
 
 .auth-card--centered {
+  justify-self: center;
   text-align: left;
+}
+
+.auth-card--logout {
+  text-align: center;
+}
+
+.auth-logout__icon {
+  align-items: center;
+  background: var(--color-bg-hero);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  color: var(--color-accent-dark);
+  display: inline-flex;
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  height: 56px;
+  justify-content: center;
+  margin-bottom: var(--space-6);
+  width: 56px;
 }
 
 .auth-link--center {
@@ -302,19 +428,40 @@
 }
 
 @media (max-width: 1199px) {
+  .messages-list:has(+ .auth-page),
+  .messages:has(+ .auth-page),
+  [data-drupal-messages]:has(+ .auth-page) {
+    padding: 0 var(--space-8);
+  }
+
   .auth-page__inner {
     gap: var(--space-10);
     grid-template-columns: 1fr;
-    max-width: 540px;
+    max-width: 620px;
     padding: var(--space-16) var(--space-8);
+  }
+
+  .auth-card {
+    justify-self: stretch;
   }
 
   .auth-hero__stats {
     display: none;
   }
+
+  .auth-page--register .auth-hero {
+    margin-bottom: 0;
+  }
 }
 
 @media (max-width: 767px) {
+  .messages-list:has(+ .auth-page),
+  .messages:has(+ .auth-page),
+  [data-drupal-messages]:has(+ .auth-page) {
+    margin: var(--space-5) auto calc(var(--space-4) * -1);
+    padding: 0 var(--space-6);
+  }
+
   .auth-page {
     min-height: auto;
   }
@@ -324,6 +471,7 @@
   }
 
   .auth-card {
+    border-radius: var(--radius-xl);
     padding: var(--space-8) var(--space-6);
   }
 
@@ -334,6 +482,21 @@
   .auth-hero__title,
   .auth-reset__title {
     font-size: var(--text-2xl);
+  }
+
+  .auth-card__title {
+    font-size: var(--text-2xl);
+  }
+
+  .auth-hero__desc,
+  .auth-reset__subtitle,
+  .auth-card__subtitle {
+    font-size: var(--text-sm);
+  }
+
+  .auth-field input,
+  .btn {
+    min-height: 58px;
   }
 
   .auth-form__row {

--- a/web/themes/custom/doljak_theme/doljak_theme.theme
+++ b/web/themes/custom/doljak_theme/doljak_theme.theme
@@ -182,19 +182,19 @@ function doljak_theme_form_contact_message_waggy_contact_form_alter(array &$form
   }
 }
 
- function doljak_theme_form_user_login_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
-    $form['#attributes']['class'][] = 'auth-form';
+function doljak_theme_form_user_login_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $form['#attributes']['class'][] = 'auth-form';
 
-    $form['name']['#wrapper_attributes']['class'][] = 'auth-field';
-    $form['name']['#attributes']['class'][] = 'auth-field__input';
+  $form['name']['#wrapper_attributes']['class'][] = 'auth-field';
+  $form['name']['#attributes']['class'][] = 'auth-field__input';
 
-    $form['pass']['#wrapper_attributes']['class'][] = 'auth-field';
-    $form['pass']['#attributes']['class'][] = 'auth-field__input';
+  $form['pass']['#wrapper_attributes']['class'][] = 'auth-field';
+  $form['pass']['#attributes']['class'][] = 'auth-field__input';
 
-    $form['actions']['submit']['#attributes']['class'][] = 'btn';
-    $form['actions']['submit']['#attributes']['class'][] = 'btn--primary';
-    $form['actions']['submit']['#attributes']['class'][] = 'btn--full';
-  }
+  $form['actions']['submit']['#attributes']['class'][] = 'btn';
+  $form['actions']['submit']['#attributes']['class'][] = 'btn--primary';
+  $form['actions']['submit']['#attributes']['class'][] = 'btn--full';
+}
 
 function doljak_theme_form_user_pass_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   $form['#attributes']['class'][] = 'auth-form';
@@ -210,7 +210,12 @@ function doljak_theme_form_user_pass_alter(array &$form, FormStateInterface $for
 
 function doljak_theme_theme_suggestions_form_alter(array &$suggestions, array $variables): void {
   $form_id = $variables['element']['#form_id'] ?? '';
-  $targets = ['user_login_form', 'user_register_form', 'user_pass'];
+  $targets = [
+    'user_login_form',
+    'user_register_form',
+    'user_pass',
+    'user_logout_confirm',
+  ];
   if (in_array($form_id, $targets)) {
     $suggestions[] = 'form__' . $form_id;
   }
@@ -230,4 +235,20 @@ function doljak_theme_form_user_register_form_alter(array &$form, FormStateInter
   $form['actions']['submit']['#attributes']['class'][] = 'btn';
   $form['actions']['submit']['#attributes']['class'][] = 'btn--primary';
   $form['actions']['submit']['#attributes']['class'][] = 'btn--full';
+}
+
+function doljak_theme_form_user_logout_confirm_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  $form['#attributes']['class'][] = 'auth-form';
+
+  if (isset($form['actions']['submit'])) {
+    $form['actions']['submit']['#attributes']['class'][] = 'btn';
+    $form['actions']['submit']['#attributes']['class'][] = 'btn--primary';
+    $form['actions']['submit']['#attributes']['class'][] = 'btn--full';
+  }
+
+  if (isset($form['actions']['cancel'])) {
+    $form['actions']['cancel']['#attributes']['class'][] = 'btn';
+    $form['actions']['cancel']['#attributes']['class'][] = 'btn--secondary';
+    $form['actions']['cancel']['#attributes']['class'][] = 'btn--full';
+  }
 }

--- a/web/themes/custom/doljak_theme/templates/form--user-logout-confirm.html.twig
+++ b/web/themes/custom/doljak_theme/templates/form--user-logout-confirm.html.twig
@@ -1,0 +1,23 @@
+<section class="auth-page auth-page--logout">
+  <div class="auth-reset__inner">
+    <p class="auth-hero__eyebrow">ACCOUNT SESSION</p>
+    <h1 class="auth-reset__title">Log out of Waggy?</h1>
+    <p class="auth-reset__subtitle">
+      Your cart and saved favorites will stay ready for the next time you sign in.
+    </p>
+
+    <div class="auth-card auth-card--centered auth-card--logout">
+      <div class="auth-logout__icon" aria-hidden="true">-&gt;</div>
+      <h2 class="auth-card__title auth-card__title--small">End current session</h2>
+      <p class="auth-card__subtitle">
+        Confirm to leave your account on this device.
+      </p>
+
+      {{ element.actions }}
+    </div>
+  </div>
+</section>
+
+{{ element.form_token }}
+{{ element.form_build_id }}
+{{ element.form_id }}


### PR DESCRIPTION
- Refines the auth journey CSS for login, register, password reset, and Drupal validation messages.
- Adds a themed logout confirmation template wired through the existing form suggestion flow.
- Adds the issue #97 spec/status doc for the remaining Paper and validation work.

Issue #97 remains open for the remaining UI review, Paper logout completion, and follow-up auth states.