### PR TITLE
fix: exclude development.services.yml from Drupal scaffold on Pantheon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,9 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
+            },
+            "file-mapping": {
+                "[web-root]/sites/development.services.yml": false
             }
         },
         "installer-paths": {


### PR DESCRIPTION
## O que mudou

- Adicionado `file-mapping` na configuração `drupal-scaffold` do `composer.json` para excluir `web/sites/development.services.yml` do scaffold do Composer.

## Por que mudou

O build do Pantheon executa `composer install`, que aciona o scaffold do Drupal core e sobrescreve `development.services.yml` com a versão padrão do pacote. O Pantheon então verifica que o arquivo foi modificado durante o build e rejeita o deploy com:

> The build step affected files that are not ignored by git: M web/sites/development.services.yml

Excluindo o arquivo do scaffold (`false` no file-mapping), o Composer para de sobrescrevê-lo e o build passa sem erros.

## O que revisar

- `composer.json` → `extra.drupal-scaffold.file-mapping`: a única mudança é a entrada `"[web-root]/sites/development.services.yml": false`.